### PR TITLE
Rename prepare script to setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It does the following actions (note, these steps will only be run on the 'master
 * Compare currently checked out branch or tag to the one we are trying to checkout. If the commit hash is the same, skip remaining steps
 * Checkout the specified GIT branch or tag
 * Initialise or update all submodule references
-* Run npm run-script prepare
+* Run npm run-script setup
 * Copy prepare directory to application specfic subdirectory of the build directory
 * Run npm run-script build inside the application subdirectory
 * Clean up the application subdirectory of any non application files

--- a/lib/run-prepare.js
+++ b/lib/run-prepare.js
@@ -7,8 +7,8 @@ module.exports = function createRunPrepare(runCmd) {
     if (data.canSkip || !context.isMaster) {
       return callback(null, data)
     }
-    context.emit('Running prepare script...')
-    var args = [ 'run-script', 'prepare' ]
+    context.emit('Running setup script...')
+    var args = [ 'run-script', 'setup' ]
       , options = { cwd: data.prepareDir }
 
     runCmd('npm'

--- a/test/lib/run-prepare.test.js
+++ b/test/lib/run-prepare.test.js
@@ -4,14 +4,14 @@ var sinon = require('sinon')
 
 describe('run-setup', function () {
 
-  it('should emit data when running prepare', function (done) {
+  it('should emit data when running setup', function (done) {
     var emitSpy = sinon.spy()
       , context = { emit: emitSpy, isMaster: true }
       , runCmd = function(cmd, args, options, onData, callback) {
           cmd.should.equal('npm')
           args.length.should.equal(2)
           args[0].should.equal('run-script')
-          args[1].should.equal('prepare')
+          args[1].should.equal('setup')
           Object.keys(options).length.should.equal(1)
           options.cwd.should.equal('/tmp')
           onData()


### PR DESCRIPTION
Npm 4 & yarn 0.23 now support a `prepare` script that gets run post install. This conflicts with our usage of `prepare` and often causes an install loop.

This commit has been made blind, but the same change was made directly on the Black Ballad server and is working, @panfantastic can you please confirm that my change here is the same as the one there?